### PR TITLE
[IMP] Product Configurator

### DIFF
--- a/product_configurator/views/product_view.xml
+++ b/product_configurator/views/product_view.xml
@@ -34,7 +34,7 @@
             <!-- TODO: Implement a method to hide this field for non-configurable product templates -->
             <xpath expr="//field[@name='attribute_line_ids']/tree/field[@name='value_ids']" position="after">
                 <field name="required" invisible="not context.get('default_config_ok', False)"/>
-                <field name="multi" invisible="not context.get('default_config_ok', False)"/>
+                <field name="multi" invisible="True" />
                 <field name="custom" invisible="not context.get('default_config_ok', False)"/>
             </xpath>
 


### PR DESCRIPTION
Quitar de la vista la posibilidad que un producto sea multi.
modifiar como funcionan las restricciones.
Si a un atributo le das valores. Si la restricción se cumple, solo se
ven esos valores.